### PR TITLE
Update configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -66,7 +66,7 @@ fi
 
 PKG_CHECK_MODULES([CONFUSE], [libconfuse], [], AC_MSG_ERROR([requires libconfuse]))
 
-PKG_CHECK_MODULES([LIBNL], [libnl-3.0], [], AC_MSG_ERROR([requires libnl]))
+PKG_CHECK_MODULES([LIBNL], [libnl-3.0], [], AC_MSG_ERROR([requires libnl3-dev]))
 PKG_CHECK_MODULES([LIBNL_ROUTE], [libnl-route-3.0], [], AC_MSG_ERROR([requires libnl3-route]))
 
 AC_CHECK_LIB(m, pow, [], AC_MSG_ERROR([requires libm]))


### PR DESCRIPTION
I reckon to add "requires libnl3-dev" instead of only libnl. I was trying to ./configure bmon for about 15 mins without success only because error message was showing me that my system is missing libnl not libnl3 :-(
