### PR TITLE
Fix ${target_os} expansion in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -26,6 +26,9 @@ AC_CONFIG_HEADERS(include/bmon/defs.h)
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIR([m4])
 
+AC_CANONICAL_TARGET
+AC_CANONICAL_SYSTEM
+
 AM_INIT_AUTOMAKE([-Wall foreign subdir-objects])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES(yes)], [])
 


### PR DESCRIPTION
Adds missing AC_CANONICAL_{TARGET,SYSTEM} calls in configure.ac
to initialize ${target_os} and other variables. Without changes
${target_os} is always undefined (an empty string).
