### PR TITLE
Fixes 'bmon -i dummy:randomize' SIGSEGV

### DIFF
--- a/src/in_dummy.c
+++ b/src/in_dummy.c
@@ -171,7 +171,7 @@ static void print_help(void)
 	"    TX-bytes   := TX-packets * (Rand() %% mtu)\n");
 }
 
-static void dummy_parse_opt(const char *value, const char *type)
+static void dummy_parse_opt(const char *type, const char *value)
 {
 	if (!strcasecmp(type, "rxb") && value)
 		c_rx_b_inc = strtol(value, NULL, 0);


### PR DESCRIPTION
Reverse 'value' and 'type' parameters order in dummy_parse_opt()
function.
