### PR TITLE
bmon: unlink list element from list before xfree()

### DIFF
--- a/src/unit.c
+++ b/src/unit.c
@@ -124,6 +124,7 @@ void fraction_free(struct fraction *f)
 	if (!f)
 		return;
 
+	list_del(&f->f_list);
 	xfree(f->f_name);
 	xfree(f);
 }


### PR DESCRIPTION
Valgrind complains:

```
==51496== Invalid write of size 8
==51496==    at 0x100002528: __list_add (list.h:34)
==51496==    by 0x100001FD4: list_add_tail (list.h:42)
==51496==    by 0x100001F9A: unit_add_div (unit.c:145)
==51496==    by 0x100003B3C: add_div (conf.c:322)
==51496==    by 0x1000030FE: configfile_read_units (conf.c:361)
==51496==    by 0x100002A5B: conf_read (conf.c:449)
==51496==    by 0x1000028AA: configfile_read (conf.c:532)
==51496==    by 0x10000A00C: main (bmon.c:285)
==51496==  Address 0x10004b300 is 16 bytes inside a block of size 32 free'd
==51496==    at 0x7237: free (in /usr/local/Cellar/valgrind/3.9.0/lib/valgrind/vgpreload_memcheck-amd64-darwin.so)
==51496==    by 0x100001622: xfree (utils.c:57)
==51496==    by 0x100001E97: fraction_free (unit.c:128)
==51496==    by 0x100003A99: add_div (conf.c:312)
==51496==    by 0x1000030FE: configfile_read_units (conf.c:361)
==51496==    by 0x100002A5B: conf_read (conf.c:449)
==51496==    by 0x1000028AA: configfile_read (conf.c:532)
==51496==    by 0x10000A00C: main (bmon.c:285)
==51496== 
==51496== Invalid read of size 4
==51496==    at 0x100001B54: unit_divisor (unit.c:88)
==51496==    by 0x100001DE8: unit_value2str (unit.c:113)
==51496==    by 0x10000752C: attr_rate2float (attr.c:346)
==51496==    by 0x100012C80: draw_element (out_curses.c:576)
==51496==    by 0x100004081: __group_foreach_element (group.c:45)
==51496==    by 0x100003FDA: group_foreach_element (group.c:57)
==51496==    by 0x100012ACE: draw_group (out_curses.c:655)
==51496==    by 0x10000428C: group_foreach (group.c:75)
==51496==    by 0x1000115D1: draw_element_list (out_curses.c:662)
==51496==    by 0x10000FE39: draw_content (out_curses.c:960)
==51496==    by 0x10000F4BC: curses_draw (out_curses.c:1053)
==51496==    by 0x10000AA41: module_foreach_run_enabled (module.c:55)
==51496==  Address 0x10004b2f0 is 0 bytes inside a block of size 32 free'd
==51496==    at 0x7237: free (in /usr/local/Cellar/valgrind/3.9.0/lib/valgrind/vgpreload_memcheck-amd64-darwin.so)
==51496==    by 0x100001622: xfree (utils.c:57)
==51496==    by 0x100001E97: fraction_free (unit.c:128)
==51496==    by 0x100003A99: add_div (conf.c:312)
==51496==    by 0x1000030FE: configfile_read_units (conf.c:361)
==51496==    by 0x100002A5B: conf_read (conf.c:449)
==51496==    by 0x1000028AA: configfile_read (conf.c:532)
==51496==    by 0x10000A00C: main (bmon.c:285)
```
