### PR TITLE
assertion failed in libConfuse

### DIFF
--- a/src/bmon.c
+++ b/src/bmon.c
@@ -220,7 +220,7 @@ static int parse_args_post(int argc, char *argv[])
 				break;
 
 			case 'a':
-				cfg_setint(cfg, "show_all", 1);
+				cfg_setbool(cfg, "show_all", cfg_true);
 				break;
 
 			case 'U':


### PR DESCRIPTION
before my patch, executing `bmon -a` on ArchLinux fails with the following message:
``bmon: confuse.c:1264: cfg_opt_setnint: Assertion `opt && opt->type == CFGT_INT' failed.``

I believe `cfg_setbool` should be the right one in this place.