### PR TITLE
Explicitly include net/if.h to fix cross-compile error

### DIFF
--- a/src/in_netlink.c
+++ b/src/in_netlink.c
@@ -37,6 +37,8 @@ static int c_notc = 0;
 static struct element_group *grp;
 static struct bmon_module netlink_ops;
 
+#include <net/if.h>
+
 #include <netlink/netlink.h>
 #include <netlink/cache.h>
 #include <netlink/utils.h>


### PR DESCRIPTION
When compiling bmon with the Linaro 2014.01 ARM toolchain
(gcc-linaro-arm-linux-gnueabihf-4.8-2014.01_linux) the following compile error occurs:

  in_netlink.c: In function ‘do_link’:
  in_netlink.c:688:53: error: ‘IFF_UP’ undeclared (first use in this function)

Fix it by explicitly including net/if.h, where IFF_UP is defined.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>