### PR TITLE
Fix wrong unit displayed when using "--use-bit" option

### DIFF
--- a/man/bmon.8
+++ b/man/bmon.8
@@ -44,7 +44,7 @@ text mode. See OUTPUT MODULES for more details.
 .PP
 \fB \-U\fR, \fB\-\-use\-si\fR
 .RS 4
-Use SI unit system instead of 1KB = 1'024 bytes.
+Use SI unit system (1KB = 1'000 bytes) instead of 1KB = 1'024 bytes.
 .RE
 .PP
 \fB \-f\fR, \fB\-\-configfile=\fRFILE

--- a/src/in_netlink.c
+++ b/src/in_netlink.c
@@ -774,6 +774,17 @@ static void netlink_shutdown(void)
 	nl_socket_free(sock);
 }
 
+static void netlink_use_bit(struct attr_map *map, const int size)
+{
+	if(cfg_getbool(cfg, "use_bit")) {
+		for(int i = 0; i < size; ++i) {
+			if(!strcmp(map[i].description, "Bytes")) {
+				map[i].description = "Bits";
+			}
+		}
+	}
+}
+
 static int netlink_do_init(void)
 {
 	int err;
@@ -798,6 +809,8 @@ static int netlink_do_init(void)
 		goto disable;
 	}
 
+	netlink_use_bit(link_attrs, ARRAY_SIZE(link_attrs));
+	netlink_use_bit(tc_attrs, ARRAY_SIZE(tc_attrs));
 	if (attr_map_load(link_attrs, ARRAY_SIZE(link_attrs)) ||
 	    attr_map_load(tc_attrs, ARRAY_SIZE(tc_attrs)))
 		BUG();
@@ -819,17 +832,17 @@ static int netlink_probe(void)
 
 	if (!(sock = nl_socket_alloc()))
 		return 0;
-	
+
 	if (nl_connect(sock, NETLINK_ROUTE) < 0)
 		return 0;
-	
+
 	if (rtnl_link_alloc_cache(sock, AF_UNSPEC, &lc) == 0) {
 		nl_cache_free(lc);
 		ret = 1;
 	}
 
 	nl_socket_free(sock);
-	
+
 	return ret;
 }
 

--- a/src/out_format.c
+++ b/src/out_format.c
@@ -189,8 +189,8 @@ static inline void add_token(int type, char *data)
 		if (out_tokens == NULL)
 			quit("Cannot reallocate out token array\n");
 	}
-		
-		
+
+
 	out_tokens[token_index].ot_type = type;
 	out_tokens[token_index].ot_str = data;
 	token_index++;
@@ -250,7 +250,7 @@ static int format_probe(void)
 			}
 
 			goto out;
-		
+
 finish_escape:
 			*p = '\0';
 			add_token(OT_STRING, s);
@@ -259,7 +259,7 @@ finish_escape:
 			continue;
 		}
 
-out:	
+out:
 		if (new_one) {
 			add_token(OT_STRING, p);
 			new_one = 0;
@@ -328,9 +328,9 @@ static void print_help(void)
 	"    \"$(element:name) $(attr:rxrate:packets) $(attr:txrate:packets)\\n\"\n" \
 	"    eth0 33 5\n" \
 	"\n" \
-	"    \"Element: $(element:name)\\nBytes Rate: \" \\\n" \
-	"        \"$(attr:rxrate:bytes)/$(attr:txrate:bytes)\\nPackets Rate: \" \\\n" \
-	"        \"$(attr:rxrate:packets)/$(attr:txrate:packets)\\n\"\n" \
+	"    \"Item: $(element:name)\\n\" \\\n" \
+	"        \"Bytes Rate: $(attr:rxrate:bytes)/$(attr:txrate:bytes)\\n\" \\\n" \
+	"        \"Packets Rate: $(attr:rxrate:packets)/$(attr:txrate:packets)\\n\"\n" \
 	"    Item: eth0\n" \
 	"    Bytes Rate: 49130/2119\n" \
 	"    Packets Rate: 40/11\n" \


### PR DESCRIPTION
The solution is hackish I admit, if you have better idea how to do it, let me know...

I am surprised that I added the static function `netlink_use_bit()` only for netlink interface but it also have effects when using proc interface (option `-i proc`).
