### PR TITLE
format: Add missing braces around 'if' clause

### DIFF
--- a/src/out_format.c
+++ b/src/out_format.c
@@ -131,9 +131,10 @@ static char *get_token(struct element_group *g, struct element *e,
 		} else if (!strncasecmp(type, "rxrate:", 7)) {
 			snprintf(buf, len, "%.2f", a->a_rx_rate.r_rate);
 			return buf;
-		} else if (!strncasecmp(token+5, "txrate:", 7))
+		} else if (!strncasecmp(type, "txrate:", 7)) {
 			snprintf(buf, len, "%.2f", a->a_tx_rate.r_rate);
 			return buf;
+		}
 	}
 
 	fprintf(stderr, "Unknown field \"%s\"\n", token);


### PR DESCRIPTION
When compiling bmon with gcc 6.1 it complains with the following
warning:

out_format.c: In function ‘get_token’:
out_format.c:134:10: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
   } else if (!strncasecmp(token+5, "txrate:", 7))
          ^~
out_format.c:136:4: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the ‘if’
    return buf;
    ^~~~~~

Indeed, the 'return buf' should only be executed if it was snprintf()'ed
to. Otherwise "unknown" should be returned. Fix this by adding braces.
Also use the 'type' variable in strncasecmp() as in the other checks.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>