### PR TITLE
Use a monotonic clock instead of a realtime clock

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -58,7 +58,7 @@ AC_CHECK_HEADERS(sys/param.h sys/socket.h)
 
 AC_CHECK_TYPES(suseconds_t)
 
-AC_CHECK_FUNCS(atexit gettimeofday memset pow socket strcasecmp)
+AC_CHECK_FUNCS(atexit clock_gettime memset pow socket strcasecmp)
 AC_CHECK_FUNCS(strchr strdup strerror strncasecmp strstr strtol)
 AC_CHECK_FUNCS(uname getdate)
 
@@ -85,6 +85,9 @@ case ${target_os} in
 esac
 
 AC_CHECK_LIB(m, pow, [], AC_MSG_ERROR([requires libm]))
+
+# Don't fail if not found (for instance, OS X does not have clock_gettime)
+AC_CHECK_LIB(rt, clock_gettime, [], [])
 
 BMON_LIB=""
 

--- a/include/bmon/defs.h.in
+++ b/include/bmon/defs.h.in
@@ -9,6 +9,9 @@
 /* Define to 1 if you have the `atexit' function. */
 #undef HAVE_ATEXIT
 
+/* Define to 1 if you have the `clock_gettime' function. */
+#undef HAVE_CLOCK_GETTIME
+
 /* have curses */
 #undef HAVE_CURSES
 
@@ -39,14 +42,14 @@
 /* Define to 1 if you have the <getopt.h> header file. */
 #undef HAVE_GETOPT_H
 
-/* Define to 1 if you have the `gettimeofday' function. */
-#undef HAVE_GETTIMEOFDAY
-
 /* Define to 1 if you have the <inttypes.h> header file. */
 #undef HAVE_INTTYPES_H
 
 /* Define to 1 if you have the `m' library (-lm). */
 #undef HAVE_LIBM
+
+/* Define to 1 if you have the `rt' library (-lrt). */
+#undef HAVE_LIBRT
 
 /* Define to 1 if you have the <memory.h> header file. */
 #undef HAVE_MEMORY_H


### PR DESCRIPTION
Using a realtime clock is a bad idea: it is affected by any kind of time
change, which can happen when the administrator modifies the system time,
or more simply when a laptop suspends to RAM and then wakes up from sleep.

With the current approach of using a realtime clock:

- if the system time jumps forward (e.g. when resuming after a
  suspend-to-RAM), bmon would take 100% CPU and display random graph data
  extremely fast, until it "catches up" with the new time.

- if the system time jumps backwards, bmon would freeze until *time*
  "catches up" to the point it was before.  bmon then (incorrectly)
  displays a spike in the graph, because lots of packets have been
  sent/received since the last update.

Instead of using gettimeofday(), switch to clock_gettime() with
CLOCK_MONOTONIC on systems that support it.  OS X does not provide
clock_gettime(), so this commit also adds a Mach-specific implementation.

This change has been tested on Linux 4.1 with glibc and musl.