### PR TITLE
Added example to man page, switched format strings to single quotes.

### DIFF
--- a/man/bmon.8
+++ b/man/bmon.8
@@ -220,6 +220,14 @@ and eth1:
 .RS 4
 \fBbmon \-p eth0,eth1 \-o curses\fP
 .RE
+.PP
+To run bmon in format mode, monitoring any eth* interfaces, with a specified
+format string:
+.PP
+.RS 4
+\fBbmon \-p \(aqeth*\(aq \-o format:fmt=\(aq$(element:name) $(attr:rxrate:packets)\en\(aq\fP
+.RE
+.PP
 
 .SH "FILES"
 /etc/bmon.conf

--- a/src/out_format.c
+++ b/src/out_format.c
@@ -326,9 +326,9 @@ static void print_help(void)
 	"    '$(element:name) $(attr:rxrate:packets) $(attr:txrate:packets)\\n'\n" \
 	"    eth0 33 5\n" \
 	"\n" \
-	"    'Item: $(element:name)\\n' \\\n" \
-	"        'Bytes Rate: $(attr:rxrate:bytes)/$(attr:txrate:bytes)\\n' \\\n" \
-	"        'Packets Rate: $(attr:rxrate:packets)/$(attr:txrate:packets)\\n'\n" \
+	"    'Item: $(element:name)\\nBytes Rate: $(attr:rxrate:bytes)/" \
+	"$(attr:txrate:bytes)\\nPackets Rate: $(attr:rxrate:packets)/" \
+	"$(attr:txrate:packets)\\n'\n" \
 	"    Item: eth0\n" \
 	"    Bytes Rate: 49130/2119\n" \
 	"    Packets Rate: 40/11\n" \

--- a/src/out_format.c
+++ b/src/out_format.c
@@ -320,15 +320,15 @@ static void print_help(void)
 	"  Supported Escape Sequences: \\n, \\t, \\r, \\v, \\b, \\f, \\a\n" \
 	"\n" \
 	"  Examples:\n" \
-	"    \"$(element:name)\\t$(attr:rx:bytes)\\t$(attr:tx:bytes)\\n\"\n" \
+	"    '$(element:name)\\t$(attr:rx:bytes)\\t$(attr:tx:bytes)\\n'\n" \
 	"    lo      12074   12074\n" \
 	"\n" \
-	"    \"$(element:name) $(attr:rxrate:packets) $(attr:txrate:packets)\\n\"\n" \
+	"    '$(element:name) $(attr:rxrate:packets) $(attr:txrate:packets)\\n'\n" \
 	"    eth0 33 5\n" \
 	"\n" \
-	"    \"Item: $(element:name)\\n\" \\\n" \
-	"        \"Bytes Rate: $(attr:rxrate:bytes)/$(attr:txrate:bytes)\\n\" \\\n" \
-	"        \"Packets Rate: $(attr:rxrate:packets)/$(attr:txrate:packets)\\n\"\n" \
+	"    'Item: $(element:name)\\n' \\\n" \
+	"        'Bytes Rate: $(attr:rxrate:bytes)/$(attr:txrate:bytes)\\n' \\\n" \
+	"        'Packets Rate: $(attr:rxrate:packets)/$(attr:txrate:packets)\\n'\n" \
 	"    Item: eth0\n" \
 	"    Bytes Rate: 49130/2119\n" \
 	"    Packets Rate: 40/11\n" \


### PR DESCRIPTION
I thought an example of the format output mode would be helpful, so I added one to the man page. I also changed the format strings in out_format.c to use single quotes instead of double quotes. This prevents the shell from evaluating our format strings as commands, since they are wrapped in `$(...)`. Lastly, I changed the long format string example to be one string as opposed to a multiline string. While the previous format looked nicer, you could not directly paste this into a bmon command and have it work correctly due to the spacing. With this format, you can do that.

I made separate commits for each of these changes, so you can cherry pick what you want if you don't want the full set.