### PR TITLE
Flushed stdout after every group is printed in an iteration.

### DIFF
--- a/src/out_ascii.c
+++ b/src/out_ascii.c
@@ -212,6 +212,7 @@ static void ascii_draw_group(struct element_group *g, void *arg)
 static void ascii_draw(void)
 {
 	group_foreach(ascii_draw_group, NULL);
+	fflush(stdout);
 
 	if (c_quit_after > 0)
 		if (--c_quit_after == 0)

--- a/src/out_format.c
+++ b/src/out_format.c
@@ -166,6 +166,7 @@ static void draw_element(struct element_group *g, struct element *e, void *arg)
 static void format_draw(void)
 {
 	group_foreach_recursive(draw_element, NULL);
+	fflush(stdout);
 
 	if (c_quit_after > 0)
 		if (--c_quit_after == 0)


### PR DESCRIPTION
This allows us to redirect ascii based output to a file. Before the manual flushing, output redirection would cause the program to produce no output. This is because when printing to the console the printf newlines will cause the buffer to flush, but for redirected output the newlines do not trigger the flushing.