### PR TITLE
Avoid trying to include <values.h> on Android

### DIFF
--- a/include/bmon/config.h
+++ b/include/bmon/config.h
@@ -48,7 +48,7 @@
 #include <dirent.h>
 #ifdef SYS_BSD
 # include <float.h>
-#else
+#elif !defined(__ANDROID__)
 # include <values.h>
 #endif
 


### PR DESCRIPTION
The <values.h> header file is not present on Android, and the project builds there without it.

This came up as an issue when packaging bmon for [Termux](https://termux.com), where it now is available. Work done by @vaites in https://github.com/termux/termux-packages/pull/758.