### PR TITLE
Allow numeric colors in bmonrc

### DIFF
--- a/include/bmon/layout.h
+++ b/include/bmon/layout.h
@@ -28,6 +28,8 @@ static int parse_color(const char* color)
         color_code = COLOR_MAGENTA;
     else if ((strcasestr(color, "cyan") != NULL))
         color_code = COLOR_CYAN;
+    else if ((atoi(color) >= 0))
+        color_code = atoi(color);
 
     return color_code;
 }


### PR DESCRIPTION
Hi,
I'm using a `$TERM` that supports 256 colors and I'd love to be able to style `bmon` accordingly.
Unfortunately I found that only the eight standard ASCII color names are available; the proposed changes allow numerical values (e.g. `123`) to be specified for the `color_pair` directive.

I look forward to feedback regarding:
* the general idea, and whether that would be a useful addition to `bmon`
* wether the changes are too simple and the max number of supported colors from the terminal should be checked or other aspects need to be taken into account
* whether you think that calling `atoi (3)` twice is acceptable
* anything else that crosses your mind while reviewing this

Here's an example `~/.bmonrc`…
```
layout colors {
    color default {
       color_pair  = {"white", "black"}
    }
    color statusbar {
        color_pair = {"green", "white"}
    }
    color header {
        color_pair = {"black", "white"}
    }
    color list {
        color_pair = {"15", "black", "reverse"}
    }
    color selected {
        color_pair = {"white", "black", "reverse"}
    }
    color RX_graph {
        color_pair = {"150", "black", "reverse"}
    }
    color TX_graph {
        color_pair = {"203", "black", "reverse"}
    }
}
```

… and the resulting bmon:
<img width="570" alt="bmon-numeric-colors" src="https://user-images.githubusercontent.com/16507/31094335-1a9c1a48-a7b5-11e7-89da-de08788254c9.png">
